### PR TITLE
Story 19 20

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,6 @@
 class SessionsController < ApplicationController
   def show
+    @user = current_user
     render file: "public/404.html" if !current_user
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,26 +4,38 @@ class UsersController < ApplicationController
     end
 
     def create
-
       user = User.new(user_params)
-
       if user.save
         session[:user_id] = user.id
         redirect_to "/profile"
-
         flash[:success] = "#{user.name} has been registered and logged in"
       else
         flash[:error] = "User could not be created: #{user.errors.full_messages.each {|msg| msg}}"
         redirect_to "/register"
       end
+    end
 
+    def edit
+      @user = current_user
+    end
+
+    def update
+      user = current_user
+      if user.update_attributes(user_params_update)
+        flash[:success] = "Your profile has been updated"
+        redirect_to "/profile"
+      else user.errors.any?
+        flash[:error] = "User could not be updated: #{user.errors.full_messages.each {|msg| msg}}"
+        redirect_to "/profile/edit"
+      end
     end
 
     private
-
     def user_params
-        params.permit(:name, :address, :city, :state, :zip, :email, :password)
+      params.permit(:name, :address, :city, :state, :zip, :email, :password)
     end
 
-
+    def user_params_update
+      params.permit(:name, :address, :city, :state, :zip, :email)
+    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
-  validates_presence_of :name, :address, :city, :state, :zip, :password
-  validates :email , presence: true, uniqueness: true
+  validates_presence_of :name, :address, :city, :state, :zip
+  validates :password, presence: true, confirmation: true, on: :create
+  validates :email, presence: true, uniqueness: true
   enum role: [:default, :merchant, :admin]
 
   has_secure_password

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -1,1 +1,9 @@
 <p><%= "Logged in as #{current_user.name}" %></p>
+
+<p>Name: <%= @user.name %></p>
+<p>Address: <%= @user.address %></p>
+<p>City: <%= @user.city %></p>
+<p>State: <%= @user.state %></p>
+<p>Zip: <%= @user.zip %></p>
+
+<%= link_to "Edit Profile", "/profile/edit" %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,24 @@
+<h1>Edit Profile</h1><br/>
+
+<%= form_tag "/profile", method: :patch do %>
+  <%= label_tag :name%><br/>
+  <%= text_field_tag :name, @user.name %>
+  <br/><br/>
+  <%= label_tag :address%><br/>
+  <%= text_field_tag :address, @user.address %>
+  <br/><br/>
+  <%= label_tag :city %><br/>
+  <%= text_field_tag :city, @user.city %>
+  <br/><br/>
+  <%= label_tag :state %><br/>
+  <%= text_field_tag :state, @user.state %>
+  <br/><br/>
+  <%= label_tag :zip%><br/>
+  <%= text_field_tag :zip, @user.zip %>
+  <br/><br/>
+  <%= label_tag :email%><br/>
+  <%= text_field_tag :email, @user.email %>
+  <br/><br/>
+
+  <%= submit_tag "Update" %>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,28 +1,28 @@
 <%= form_tag "/users", method: :post do %>
-    <%= label_tag :name%>
+    <%= label_tag :name%><br/>
     <%= text_field_tag :name %>
-    <br/>
-    <%= label_tag :address%>
+    <br/><br/>
+    <%= label_tag :address%><br/>
     <%= text_field_tag :address %>
-    <br/>
-    <%= label_tag :city %>
+    <br/><br/>
+    <%= label_tag :city %><br/>
     <%= text_field_tag :city %>
-    <br/>
-    <%= label_tag :state %>
+    <br/><br/>
+    <%= label_tag :state %><br/>
     <%= text_field_tag :state %>
-    <br/>
-    <%= label_tag :zip%>
-        <%= text_field_tag :zip %>
-    <br/>
-    <%= label_tag :email%>
+    <br/><br/>
+    <%= label_tag :zip%><br/>
+    <%= text_field_tag :zip %>
+    <br/><br/>
+    <%= label_tag :email%><br/>
     <%= text_field_tag :email %>
-    <br/>
-    <%= label_tag :password %>
+    <br/><br/>
+    <%= label_tag :password %><br/>
     <%= password_field_tag :password %>
-    <br/>
-    <%= label_tag :confirm_password %>
+    <br/><br/>
+    <%= label_tag :confirm_password %><br/>
     <%= password_field_tag :confirm_password %>
-        <br/>
+    <br/><br/>
 
-        <%= submit_tag "submit" %>
+    <%= submit_tag "submit" %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,8 @@ Rails.application.routes.draw do
 
   get "/register", to: "users#new"
   post "/users", to: "users#create"
+  get "/profile/edit", to: "users#edit"
+  patch "/profile", to: "users#update"
 
   get "/profile", to: "sessions#show"
   get "/login", to: "sessions#new"

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe "User can edit their profile data" do
       fill_in :zip,	with: "80124"
       fill_in :email,	with: "test@test.com"
 
+      expect(page).to_not have_content("Password")
+
       click_button "Update"
 
       expect(current_path).to eq("/profile")
@@ -35,8 +37,28 @@ RSpec.describe "User can edit their profile data" do
       expect(page).to have_content("State: #{@jim.state}")
       expect(page).to have_content("Zip: #{@jim.zip}")
     end
+
+    it "Sad path for: can edit the users data. Not all fields are filled out" do
+      visit "/profile"
+
+      click_on "Edit Profile"
+
+      expect(current_path).to eq("/profile/edit")
+
+      fill_in :name,	with: "Jimmy"
+      fill_in :address,	with: "3455 LKV Rd."
+      fill_in :city,	with: ""
+      fill_in :state,	with: "CO"
+      fill_in :zip,	with: ""
+      fill_in :email,	with: "test@test.com"
+
+      click_button "Update"
+
+      expect(page).to have_content("User could not be updated:")
+      expect(current_path).to eq("/profile/edit")
+      expect(page).to have_content("City can't be blank")
+      expect(page).to have_content("Zip can't be blank")
+
+    end
   end
 end
-
-# The form is prepopulated with all my current information except my password
-# When I change any or all of that information

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe "User can edit their profile data" do
+  describe "As a registered user" do
+    before :each do
+      @jim = User.create(name: "Jim", address: "3455 LKV Rd.", city: "Denver", state: "CO", email: "test@test.com", zip: "80124", password: "123456")
+      visit '/login'
+      fill_in :email,	with: "test@test.com"
+      fill_in :password,	with: "123456"
+      click_button "Login"
+    end
+
+    it "can edit the users data" do
+      visit "/profile"
+
+      click_on "Edit Profile"
+
+      expect(current_path).to eq("/profile/edit")
+
+      fill_in :name,	with: "Jimmy"
+      fill_in :address,	with: "3455 LKV Rd."
+      fill_in :city,	with: "Lakewood"
+      fill_in :state,	with: "CO"
+      fill_in :zip,	with: "80124"
+      fill_in :email,	with: "test@test.com"
+
+      click_button "Update"
+
+      expect(current_path).to eq("/profile")
+      expect(page).to have_content("Your profile has been updated")
+
+      expect(page).to have_content("Name: Jimmy")
+      expect(page).to have_content("Address: #{@jim.address}")
+      expect(page).to have_content("Lakewood")
+      expect(page).to have_content("State: #{@jim.state}")
+      expect(page).to have_content("Zip: #{@jim.zip}")
+    end
+  end
+end
+
+# The form is prepopulated with all my current information except my password
+# When I change any or all of that information

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -13,11 +13,12 @@ RSpec.describe "User profile show page" do
     it "text" do
       visit "/profile"
 
+      expect(current_path).to eq("/profile")
       expect(page).to have_content("Name: #{@jim.name}")
       expect(page).to have_content("Address: #{@jim.address}")
       expect(page).to have_content("City: #{@jim.city}")
       expect(page).to have_content("State: #{@jim.state}")
-      expect(page).to have_content("zip: #{@jim.zip}")
+      expect(page).to have_content("Zip: #{@jim.zip}")
       expect(page).to_not have_content(@jim.password)
       expect(page).to have_link("Edit Profile")
     end

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "User profile show page" do
+  describe "As a registered user" do
+    before :each do
+      @jim = User.create(name: "Jim", address: "3455 LKV Rd.", city: "Denver", state: "CO", email: "test@test.com", zip: "80124", password: "123456")
+      visit '/login'
+      fill_in :email,	with: "test@test.com"
+      fill_in :password,	with: "123456"
+      click_button "Login"
+    end
+
+    it "text" do
+      visit "/profile"
+
+      expect(page).to have_content("Name: #{@jim.name}")
+      expect(page).to have_content("Address: #{@jim.address}")
+      expect(page).to have_content("City: #{@jim.city}")
+      expect(page).to have_content("State: #{@jim.state}")
+      expect(page).to have_content("zip: #{@jim.zip}")
+      expect(page).to_not have_content(@jim.password)
+      expect(page).to have_link("Edit Profile")
+    end
+  end
+end

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "User profile show page" do
       click_button "Login"
     end
 
-    it "text" do
+    it "has users attributes on the profile show page" do
       visit "/profile"
 
       expect(current_path).to eq("/profile")


### PR DESCRIPTION
-Created profile show page that shows the users information and has a link to edit users information
-Edit link goes to an edit page
   -Where all the text fields are pre populated
   -Password text field is not in the edit page
-Changed user model password validation. Added :  "validates :password, presence: true, confirmation: true, on: :create"
   -"on: :create" --> This allows us to bypass the password validation when updating the users information by only requiring 
     validation when created